### PR TITLE
Manually backport v0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightning-utilities" %}
-{% set version = "0.4.2" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lightning-utilities-{{ version }}.tar.gz
-  sha256: dc6696ab180117f7e97b5488dac1d77765ab891022f7521a97a39e10d362bdb8
+  sha256: d769ab9b76ebdee3243d1051d509aafee57d7947734ddc22977deef8a6427f2f
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
   run:
     - python >=3.8
+    - fire >=0.4
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] ~~Bumped the build number (if the version is unchanged)~~
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR is necessary to get the pytorch-lightning-feedstock to work for versions 1.8.0--1.8.3 as per [this](https://github.com/conda-forge/pytorch-lightning-feedstock/pull/105#issuecomment-1341983107) comment. 

The added dependency "fire" seems only necessary for their build-tools, which are packaged in the wheel itself under `lightning_utilties.dev`. So it's not really a run-dependency, but still necessary to make the build pass. It looks like they've changed this with 0.4.x, but the mentioned pytorch-lightning versions are [hard coded](https://github.com/Lightning-AI/lightning/blob/1.8.0/requirements/pytorch/base.txt#L14) to `lightning-utilties=0.3.*`.

So future releases don't really need the added dependency on fire. Not sure what that means for how this change should be merged. Happy to hear what you think.